### PR TITLE
Remove unnecessary defaults

### DIFF
--- a/DNSInfo.psm1
+++ b/DNSInfo.psm1
@@ -41,7 +41,7 @@ Doesn't output current DNS information
     [CmdletBinding()]
     Param
     (
-        [Switch]$NoOutput = $False
+        [Switch]$NoOutput
     )
 
     #Get Domain Connected Network Adapter
@@ -119,11 +119,11 @@ Set-DNSInfo -NewDNS "1.1.1.1,2.2.2.2,3.3.3.3,4.4.4.4" -Backup -ResetLog -SkipDHC
     (
         [Parameter(Mandatory = $True)]
         [String]$NewDNS,
-        [Switch]$Backup = $False,
-        [Switch]$ResetLog = $False,
+        [Switch]$Backup,
+        [Switch]$ResetLog,
         [String]$LogDir = $ENV:TEMP,
         [String]$BackupDir = $ENV:TEMP,
-        [Switch]$SkipDHCPCheck = $False
+        [Switch]$SkipDHCPCheck
     )
 
     #Split $NewDNS String


### PR DESCRIPTION
`[switch]` parameter values default to `$false` when not passed by the caller